### PR TITLE
Updated semopenalex ontology SHACL second version and added default diagram

### DIFF
--- a/ontologies/semopenalex-ontology-shacl.ttl
+++ b/ontologies/semopenalex-ontology-shacl.ttl
@@ -7,187 +7,275 @@
 @prefix sp: <http://spinrdf.org/sp#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-<http://purl.org/dc/terms/creator> a owl:ObjectProperty .
+<https://semopenalex.org/vocab#> a owl:Ontology;
+  <http://purl.org/dc/terms/title> "SemOpenAlex Ontology"@en;
+  rdfs:label "SemOpenAlex Ontology"@en;
+  rdfs:comment "The Semantic OpenAlex Ontology, described using W3C RDF Schema and the Web Ontology Language OWL."@en;
+  owl:versionInfo "2.0.0" .
+  
+<http://purl.org/dc/terms/creator> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/dc/terms/title> a owl:DatatypeProperty .
+<http://purl.org/dc/terms/title> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-rdfs:seeAlso a owl:ObjectProperty .
+rdfs:seeAlso a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 skos:Concept a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "Concept"@en .
 
-skos:broader a owl:ObjectProperty .
+skos:broader a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-skos:note a owl:DatatypeProperty .
+skos:note a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-skos:prefLabel a owl:DatatypeProperty .
+skos:prefLabel a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-skos:related a owl:ObjectProperty .
+skos:related a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/dc/terms/created> a owl:DatatypeProperty .
+<http://purl.org/dc/terms/created> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/dc/terms/modified> a owl:DatatypeProperty .
+<http://purl.org/dc/terms/modified> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-foaf:homepage a owl:DatatypeProperty .
+foaf:homepage a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-foaf:name a owl:DatatypeProperty .
+foaf:name a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/vocab#> a owl:Ontology;
-  rdfs:label "SemOpenAlex Ontology"@en;
-  rdfs:comment "The Semantic OpenAlex Ontology, described using W3C RDF Schema and the Web Ontology Language OWL."@en .
-
-<http://www.w3.org/ns/org#memberOf> a owl:ObjectProperty .
+<http://www.w3.org/ns/org#memberOf> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 <https://semopenalex.org/class/Author> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "Author"@en .
 
 <https://semopenalex.org/class/Institution> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "Institution"@en .
 
-<https://semopenalex.org/property/hasRelatedWork> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasRelatedWork> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 <https://semopenalex.org/class/Work> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "Work"@en .
 
-<https://semopenalex.org/property/hasAssociatedInstitution> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasAssociatedInstitution> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/hasConcept> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasConcept> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 <https://semopenalex.org/class/ConceptScore> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "ConceptScore"@en .
 
-<https://semopenalex.org/property/hasConceptScore> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasConceptScore> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/spar/cito/cites> a owl:ObjectProperty .
+<http://purl.org/spar/cito/cites> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/countsByYear> a owl:ObjectProperty .
+<https://semopenalex.org/property/countsByYear> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 <https://semopenalex.org/class/Concept> a owl:Class;
   rdfs:subClassOf skos:Concept;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "Concept"@en .
 
-<https://semopenalex.org/class/Venue> a owl:Class;
-  rdfs:label "Venue"@en .
-
 <https://semopenalex.org/class/CountsByYear> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "CountsByYear"@en .
 
-<https://semopenalex.org/property/hasHostVenue> a owl:ObjectProperty .
-
-<https://semopenalex.org/class/HostVenue> a owl:Class;
-  rdfs:label "HostVenue"@en .
-
-<https://semopenalex.org/property/hasAlternativeHostVenue> a owl:ObjectProperty .
-
-<https://semopenalex.org/property/hasVenue> a owl:ObjectProperty .
-
-<https://semopenalex.org/property/hasOpenAccess> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasOpenAccess> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 <https://semopenalex.org/class/OpenAccess> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "OpenAccess"@en .
 
-<http://dbpedia.org/ontology/location> a owl:ObjectProperty .
+<http://dbpedia.org/ontology/location> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
 <https://semopenalex.org/class/Geo> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "Geo"@en .
 
-<http://purl.org/spar/fabio/hasPubMedId> a owl:DatatypeProperty .
+<http://purl.org/spar/fabio/hasPubMedId> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/spar/fabio/hasPubMedCentralId> a owl:DatatypeProperty .
+<http://purl.org/spar/fabio/hasPubMedCentralId> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/worksCount> a owl:DatatypeProperty .
+<https://semopenalex.org/property/worksCount> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/dc/terms/abstract> a owl:DatatypeProperty .
+<http://purl.org/dc/terms/abstract> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/magId> a owl:DatatypeProperty .
+<https://semopenalex.org/property/magId> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/spar/fabio/hasPublicationYear> a owl:DatatypeProperty .
+<http://purl.org/spar/fabio/hasPublicationYear> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://prismstandard.org/namespaces/basic/2.0/publicationDate> a owl:DatatypeProperty .
+<http://prismstandard.org/namespaces/basic/2.0/publicationDate> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://prismstandard.org/namespaces/basic/2.0/doi> a owl:DatatypeProperty .
+<http://prismstandard.org/namespaces/basic/2.0/doi> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/isRetracted> a owl:DatatypeProperty .
+<https://semopenalex.org/property/isRetracted> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/isParatext> a owl:DatatypeProperty .
+<https://semopenalex.org/property/isParatext> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/isOa> a owl:DatatypeProperty .
+<https://semopenalex.org/property/isOa> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/oaStatus> a owl:DatatypeProperty .
+<https://semopenalex.org/property/oaStatus> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/oaUrl> a owl:DatatypeProperty .
+<https://semopenalex.org/property/oaUrl> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://prismstandard.org/namespaces/basic/2.0/startingPage> a owl:DatatypeProperty .
+<http://prismstandard.org/namespaces/basic/2.0/startingPage> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://prismstandard.org/namespaces/basic/2.0/endingPage> a owl:DatatypeProperty .
+<http://prismstandard.org/namespaces/basic/2.0/endingPage> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/hasVolume> a owl:DatatypeProperty .
+<https://semopenalex.org/property/hasVolume> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/hasIssue> a owl:DatatypeProperty .
+<https://semopenalex.org/property/hasIssue> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/citedByCount> a owl:DatatypeProperty .
+<https://semopenalex.org/property/citedByCount> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/dc/terms/license> a owl:DatatypeProperty .
+<http://purl.org/dc/terms/license> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/spar/fabio/hasURL> a owl:DatatypeProperty .
+<http://purl.org/spar/fabio/hasURL> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/hasVersion> a owl:DatatypeProperty .
+<https://semopenalex.org/property/hasVersion> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://prismstandard.org/namespaces/basic/2.0/issn> a owl:DatatypeProperty .
+<http://prismstandard.org/namespaces/basic/2.0/issn> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/spar/fabio/hasIssnL> a owl:DatatypeProperty .
+<http://purl.org/spar/fabio/hasIssnL> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/isInDoaj> a owl:DatatypeProperty .
+<https://semopenalex.org/property/isInDoaj> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://purl.org/dc/terms/publisher> a owl:DatatypeProperty .
+<http://purl.org/dc/terms/publisher> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/country> a owl:DatatypeProperty .
+<https://dbpedia.org/property/country> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/city> a owl:DatatypeProperty .
+<https://dbpedia.org/property/city> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://www.geonames.org/ontology#geonamesID> a owl:DatatypeProperty .
+<http://www.geonames.org/ontology#geonamesID> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/region> a owl:DatatypeProperty .
+<https://dbpedia.org/property/region> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://www.geonames.org/ontology#countryCode> a owl:DatatypeProperty .
+<http://www.geonames.org/ontology#countryCode> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://www.geonames.org/ontology#lat> a owl:DatatypeProperty .
+<http://www.geonames.org/ontology#lat> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<http://www.geonames.org/ontology#long> a owl:DatatypeProperty .
+<http://www.geonames.org/ontology#long> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/ontology/alternativeName> a owl:DatatypeProperty .
+<https://dbpedia.org/ontology/alternativeName> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/acronym> a owl:DatatypeProperty .
+<https://dbpedia.org/property/acronym> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/imageThumbnail> a owl:DatatypeProperty .
+<https://semopenalex.org/property/imageThumbnail> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-foaf:depiction a owl:DatatypeProperty .
+foaf:depiction a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/rorType> a owl:DatatypeProperty .
+<https://semopenalex.org/property/rorType> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/countryCode> a owl:DatatypeProperty .
+<https://dbpedia.org/property/countryCode> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/grid> a owl:DatatypeProperty .
+<https://semopenalex.org/property/grid> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/ror> a owl:DatatypeProperty .
+<https://semopenalex.org/property/ror> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/year> a owl:DatatypeProperty .
+<https://semopenalex.org/property/year> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/alternativeName> a owl:DatatypeProperty .
+<https://semopenalex.org/property/alternativeName> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/twitter> a owl:DatatypeProperty .
+<https://dbpedia.org/property/twitter> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/property/scopus> a owl:DatatypeProperty .
+<https://dbpedia.org/property/scopus> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://dbpedia.org/ontology/orcidId> a owl:DatatypeProperty .
+<https://dbpedia.org/ontology/orcidId> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/level> a owl:DatatypeProperty .
+<https://semopenalex.org/property/level> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/umlsAui> a owl:DatatypeProperty .
+<https://semopenalex.org/property/umlsAui> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/umlsCui> a owl:DatatypeProperty .
+<https://semopenalex.org/property/umlsCui> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/score> a owl:DatatypeProperty .
+<https://semopenalex.org/property/score> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
+
+<https://semopenalex.org/class/Publisher> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "Publisher"@en .
+
+<http://purl.org/spar/bido/h-index> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "h-index"@en .
+
+<https://semopenalex.org/property/i10Index> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "i10Index"@en .
+
+<https://semopenalex.org/property/2YrMeanCitedness> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "2YrMeanCitedness"@en .
+
+<https://semopenalex.org/property/hasParentPublisher> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "hasParentPublisher"@en .
 
 skos:ConceptShape a sh:NodeShape;
   sh:property <https://semopenalex.org/vocab#0505f27824e6216f6cefdbd4e005817d>, <https://semopenalex.org/vocab#09f17fcc61f87f9692f33bab42323734>,
@@ -195,21 +283,17 @@ skos:ConceptShape a sh:NodeShape;
     <https://semopenalex.org/vocab#8d3b7b435bad00f06370e5537dceb0ca>;
   sh:targetClass skos:Concept .
 
-<https://semopenalex.org/vocab#0505f27824e6216f6cefdbd4e005817d> a sh:PropertyShape;
-  sh:path skos:related;
-  sh:class skos:Concept .
+<https://semopenalex.org/vocab#0505f27824e6216f6cefdbd4e005817d> a sh:PropertyShape .
 
-<https://semopenalex.org/vocab#09f17fcc61f87f9692f33bab42323734> a sh:PropertyShape;
-  sh:path skos:broader;
-  sh:class skos:Concept .
+<https://semopenalex.org/vocab#09f17fcc61f87f9692f33bab42323734> a sh:PropertyShape .
 
 <https://semopenalex.org/vocab#7e72e214b08c0478192cb924f8fdd396> a sh:PropertyShape;
   sh:path rdfs:seeAlso;
   sh:class <http://purl.org/spar/fabio/WikipediaEntry>;
   sh:or ([
-        sh:class skos:Concept
-      ] [
         sh:class <https://semopenalex.org/class/Institution>
+      ] [
+        sh:class skos:Concept
       ]) .
 
 <https://semopenalex.org/vocab#8a9c850e30c57eeae19bc32d2ab5aea0> a sh:PropertyShape;
@@ -221,6 +305,7 @@ skos:ConceptShape a sh:NodeShape;
   sh:datatype xsd:string .
 
 <https://semopenalex.org/class/AuthorPosition> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
   rdfs:label "AuthorPosition"@en .
 
 <https://semopenalex.org/class/AuthorPositionShape> a sh:NodeShape;
@@ -255,32 +340,32 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#3e2f60daa912b4bbfdda79d75fe2752b> a sh:PropertyShape;
   sh:path <http://purl.org/dc/terms/modified>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Author>
+        sh:class <https://semopenalex.org/class/Work>
       ] [
-        sh:class <https://semopenalex.org/class/Concept>
+        sh:class <https://semopenalex.org/class/Source>
       ] [
         sh:class <https://semopenalex.org/class/Institution>
       ] [
-        sh:class <https://semopenalex.org/class/Venue>
+        sh:class <https://semopenalex.org/class/Concept>
       ] [
-        sh:class <https://semopenalex.org/class/Work>
+        sh:class <https://semopenalex.org/class/Author>
       ]);
   sh:datatype xsd:date .
 
 <https://semopenalex.org/vocab#534f665d25d906da0a8c33c199207f86> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/citedByCount>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/CountsByYear>
-      ] [
-        sh:class <https://semopenalex.org/class/Venue>
-      ] [
-        sh:class <https://semopenalex.org/class/Institution>
-      ] [
-        sh:class <https://semopenalex.org/class/Concept>
+        sh:class <https://semopenalex.org/class/Work>
       ] [
         sh:class <https://semopenalex.org/class/Author>
       ] [
-        sh:class <https://semopenalex.org/class/Work>
+        sh:class <https://semopenalex.org/class/Concept>
+      ] [
+        sh:class <https://semopenalex.org/class/Institution>
+      ] [
+        sh:class <https://semopenalex.org/class/Source>
+      ] [
+        sh:class <https://semopenalex.org/class/CountsByYear>
       ]);
   sh:datatype xsd:integer .
 
@@ -288,13 +373,13 @@ skos:ConceptShape a sh:NodeShape;
   sh:path <https://semopenalex.org/property/countsByYear>;
   sh:class <https://semopenalex.org/class/CountsByYear>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Work>
-      ] [
-        sh:class <https://semopenalex.org/class/Venue>
+        sh:class <https://semopenalex.org/class/Concept>
       ] [
         sh:class <https://semopenalex.org/class/Author>
       ] [
-        sh:class <https://semopenalex.org/class/Concept>
+        sh:class <https://semopenalex.org/class/Source>
+      ] [
+        sh:class <https://semopenalex.org/class/Work>
       ]) .
 
 <https://semopenalex.org/vocab#6477781c0083ed6ae289b7101034070e> a sh:PropertyShape;
@@ -304,11 +389,11 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#893797ba8898177df5b817ba86554a38> a sh:PropertyShape;
   sh:path foaf:name;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Author>
+        sh:class <https://semopenalex.org/class/Source>
       ] [
         sh:class <https://semopenalex.org/class/Institution>
       ] [
-        sh:class <https://semopenalex.org/class/Venue>
+        sh:class <https://semopenalex.org/class/Author>
       ]);
   sh:datatype xsd:string .
 
@@ -319,45 +404,45 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#b24dbbf3333905048d57498219f7c8c2> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/magId>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Author>
+        sh:class <https://semopenalex.org/class/Work>
       ] [
-        sh:class <https://semopenalex.org/class/Concept>
+        sh:class <https://semopenalex.org/class/Source>
       ] [
         sh:class <https://semopenalex.org/class/Institution>
       ] [
-        sh:class <https://semopenalex.org/class/Venue>
+        sh:class <https://semopenalex.org/class/Concept>
       ] [
-        sh:class <https://semopenalex.org/class/Work>
+        sh:class <https://semopenalex.org/class/Author>
       ]);
   sh:datatype xsd:integer .
 
 <https://semopenalex.org/vocab#bb72667cc1ad07ac0375082b6b947fe1> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/worksCount>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/CountsByYear>
-      ] [
-        sh:class <https://semopenalex.org/class/Venue>
-      ] [
-        sh:class <https://semopenalex.org/class/Institution>
+        sh:class <https://semopenalex.org/class/Author>
       ] [
         sh:class <https://semopenalex.org/class/Concept>
       ] [
-        sh:class <https://semopenalex.org/class/Author>
+        sh:class <https://semopenalex.org/class/Institution>
+      ] [
+        sh:class <https://semopenalex.org/class/Source>
+      ] [
+        sh:class <https://semopenalex.org/class/CountsByYear>
       ]);
   sh:datatype xsd:integer .
 
 <https://semopenalex.org/vocab#f31288f45557f654fc2db4a369bebfa7> a sh:PropertyShape;
   sh:path <http://purl.org/dc/terms/created>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Author>
+        sh:class <https://semopenalex.org/class/Work>
       ] [
-        sh:class <https://semopenalex.org/class/Concept>
+        sh:class <https://semopenalex.org/class/Source>
       ] [
         sh:class <https://semopenalex.org/class/Institution>
       ] [
-        sh:class <https://semopenalex.org/class/Venue>
+        sh:class <https://semopenalex.org/class/Concept>
       ] [
-        sh:class <https://semopenalex.org/class/Work>
+        sh:class <https://semopenalex.org/class/Author>
       ]);
   sh:datatype xsd:date .
 
@@ -366,17 +451,14 @@ skos:ConceptShape a sh:NodeShape;
   sh:datatype xsd:string .
 
 <https://semopenalex.org/class/ConceptScoreShape> a sh:NodeShape;
-  sh:property <https://semopenalex.org/vocab#2183731b5316d244e42f7f4bb5d53178>, <https://semopenalex.org/vocab#aea2f1abde128f871dee5d3bfe5e02fa>;
+  sh:property <https://semopenalex.org/vocab#2183731b5316d244e42f7f4bb5d53178>, <https://semopenalex.org/vocab#aea2f1abde128f871dee5d3bfe5e02fa>,
+    [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/hasConcept>;
+      sh:class skos:Concept
+    ];
   sh:targetClass <https://semopenalex.org/class/ConceptScore> .
 
-<https://semopenalex.org/vocab#2183731b5316d244e42f7f4bb5d53178> a sh:PropertyShape;
-  sh:path <https://semopenalex.org/property/hasConcept>;
-  sh:class skos:Concept;
-  sh:or ([
-        sh:class <https://semopenalex.org/class/ConceptScore>
-      ] [
-        sh:class <https://semopenalex.org/class/Work>
-      ]) .
+<https://semopenalex.org/vocab#2183731b5316d244e42f7f4bb5d53178> a sh:PropertyShape .
 
 <https://semopenalex.org/vocab#aea2f1abde128f871dee5d3bfe5e02fa> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/score>;
@@ -394,9 +476,9 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#07fe8d090dee52aa25cacf9ba01c537d> a sh:PropertyShape;
   sh:path foaf:depiction;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Concept>
-      ] [
         sh:class <https://semopenalex.org/class/Institution>
+      ] [
+        sh:class <https://semopenalex.org/class/Concept>
       ]);
   sh:datatype xsd:string .
 
@@ -411,9 +493,9 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#d780b88e0412f91d5725d74b7b2da814> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/imageThumbnail>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Concept>
-      ] [
         sh:class <https://semopenalex.org/class/Institution>
+      ] [
+        sh:class <https://semopenalex.org/class/Concept>
       ]);
   sh:datatype xsd:string .
 
@@ -468,16 +550,19 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/class/HostVenueShape> a sh:NodeShape;
   sh:property <https://semopenalex.org/vocab#189d841b1771b070e525aa80a66987e5>, <https://semopenalex.org/vocab#23348fdc99b5798e624fe091e0b4709d>,
     <https://semopenalex.org/vocab#330235a73dd4a216315cf40345bf056b>, <https://semopenalex.org/vocab#3494e2ce7122eeac1b765ba1aa7e89f7>,
-    <https://semopenalex.org/vocab#f560b07f741a900b03806de5c0ba9e2c>;
-  sh:targetClass <https://semopenalex.org/class/HostVenue> .
+    <https://semopenalex.org/vocab#f560b07f741a900b03806de5c0ba9e2c>, [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/vocab#pdfUrl>;
+      sh:datatype xsd:string
+    ];
+  sh:targetClass <https://semopenalex.org/class/Location> .
 
 <https://semopenalex.org/vocab#189d841b1771b070e525aa80a66987e5> a sh:PropertyShape;
-  sh:path <https://semopenalex.org/property/hasVenue>;
-  sh:class <https://semopenalex.org/class/Venue> .
+  sh:path <https://semopenalex.org/property/hasSource>;
+  sh:class <https://semopenalex.org/class/Source> .
 
 <https://semopenalex.org/vocab#23348fdc99b5798e624fe091e0b4709d> a sh:PropertyShape;
   sh:path <http://purl.org/spar/fabio/hasURL>;
-  sh:datatype xsd:anyURI .
+  sh:datatype xsd:string .
 
 <https://semopenalex.org/vocab#330235a73dd4a216315cf40345bf056b> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/hasVersion>;
@@ -490,11 +575,11 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#f560b07f741a900b03806de5c0ba9e2c> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/isOa>;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Venue>
-      ] [
-        sh:class <https://semopenalex.org/class/HostVenue>
-      ] [
         sh:class <https://semopenalex.org/class/OpenAccess>
+      ] [
+        sh:class <https://semopenalex.org/class/Location>
+      ] [
+        sh:class <https://semopenalex.org/class/Source>
       ]);
   sh:datatype xsd:boolean .
 
@@ -513,9 +598,9 @@ skos:ConceptShape a sh:NodeShape;
 <https://semopenalex.org/vocab#0d30180e88607a9b9f3e7efdf6a5a920> a sh:PropertyShape;
   sh:path foaf:homepage;
   sh:or ([
-        sh:class <https://semopenalex.org/class/Institution>
+        sh:class <https://semopenalex.org/class/Source>
       ] [
-        sh:class <https://semopenalex.org/class/Venue>
+        sh:class <https://semopenalex.org/class/Institution>
       ]);
   sh:datatype xsd:anyURI .
 
@@ -571,8 +656,32 @@ skos:ConceptShape a sh:NodeShape;
     <https://semopenalex.org/vocab#f31288f45557f654fc2db4a369bebfa7>, <https://semopenalex.org/vocab#f560b07f741a900b03806de5c0ba9e2c>,
     <https://semopenalex.org/vocab#0d30180e88607a9b9f3e7efdf6a5a920>, <https://semopenalex.org/vocab#008cf57371f432ebda26fe0792875368>,
     <https://semopenalex.org/vocab#80210bf1e2b1e8d223b924567b6bad92>, <https://semopenalex.org/vocab#8d659e64665e42d94499977b0d77daf6>,
-    <https://semopenalex.org/vocab#9259d4c1ba62f9565e7a21a70687ecb1>;
-  sh:targetClass <https://semopenalex.org/class/Venue> .
+    <https://semopenalex.org/vocab#9259d4c1ba62f9565e7a21a70687ecb1>, [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/abbreviatedName>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/sourceType>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/hasHostOrganization>;
+      sh:class <https://semopenalex.org/class/Publisher>
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/hasHostOrganization>;
+      sh:class <https://semopenalex.org/class/Institution>
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/apcUsd>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/fatcatId>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <http://www.geonames.org/ontology#countryCode>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <https://dbpedia.org/ontology/alternativeName>;
+      sh:datatype xsd:string
+    ];
+  sh:targetClass <https://semopenalex.org/class/Source> .
 
 <https://semopenalex.org/vocab#008cf57371f432ebda26fe0792875368> a sh:PropertyShape;
   sh:path <https://semopenalex.org/property/isInDoaj>;
@@ -604,7 +713,14 @@ skos:ConceptShape a sh:NodeShape;
     <https://semopenalex.org/vocab#ad4739516afbc43b5b3ab535bc5b81ef>, <https://semopenalex.org/vocab#af99a5a81b65696be8c769bf36a9b633>,
     <https://semopenalex.org/vocab#b05af3d161aa7b1cbc624e43d5713970>, <https://semopenalex.org/vocab#d186da23412071992d2c55668fbdd101>,
     <https://semopenalex.org/vocab#d206e9f60b0f09d55eaf45500c6eb411>, <https://semopenalex.org/vocab#e8a0e16f9a3195b262e677cac1e8ac67>,
-    <https://semopenalex.org/vocab#efa5ac5368669aaecc31eabadf5219f5>, <https://semopenalex.org/vocab#fe5d6c5f112271527e2c7abee8c5ea22>;
+    <https://semopenalex.org/vocab#efa5ac5368669aaecc31eabadf5219f5>, <https://semopenalex.org/vocab#fe5d6c5f112271527e2c7abee8c5ea22>,
+    [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/hasConcept>;
+      sh:class skos:Concept
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/hasBestOaLocation>;
+      sh:class <https://semopenalex.org/class/Location>
+    ];
   sh:targetClass <https://semopenalex.org/class/Work> .
 
 <https://semopenalex.org/vocab#013f2f63f0b01681bb2b6bee1410bea9> a sh:PropertyShape;
@@ -680,12 +796,12 @@ skos:ConceptShape a sh:NodeShape;
   sh:datatype xsd:string .
 
 <https://semopenalex.org/vocab#d206e9f60b0f09d55eaf45500c6eb411> a sh:PropertyShape;
-  sh:path <https://semopenalex.org/property/hasHostVenue>;
-  sh:class <https://semopenalex.org/class/HostVenue> .
+  sh:path <https://semopenalex.org/property/hasPrimaryLocation>;
+  sh:class <https://semopenalex.org/class/Location> .
 
 <https://semopenalex.org/vocab#e8a0e16f9a3195b262e677cac1e8ac67> a sh:PropertyShape;
-  sh:path <https://semopenalex.org/property/hasAlternativeHostVenue>;
-  sh:class <https://semopenalex.org/class/HostVenue> .
+  sh:path <https://semopenalex.org/property/hasLocation>;
+  sh:class <https://semopenalex.org/class/Location> .
 
 <https://semopenalex.org/vocab#efa5ac5368669aaecc31eabadf5219f5> a sh:PropertyShape;
   sh:path <http://prismstandard.org/namespaces/basic/2.0/startingPage>;
@@ -695,10 +811,106 @@ skos:ConceptShape a sh:NodeShape;
   sh:path <https://semopenalex.org/property/hasRelatedWork>;
   sh:class <https://semopenalex.org/class/Work> .
 
-<https://semopenalex.org/property/crossrefType> a owl:DatatypeProperty .
+<https://semopenalex.org/property/crossrefType> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/hasAuthor> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasAuthor> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/hasAuthorPosition> a owl:ObjectProperty .
+<https://semopenalex.org/property/hasAuthorPosition> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
 
-<https://semopenalex.org/property/position> a owl:DatatypeProperty .
+<https://semopenalex.org/property/position> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
+
+<https://semopenalex.org/class/Source> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "Source"@en .
+
+<https://semopenalex.org/class/Location> a owl:Class;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "Location"@en .
+
+<https://semopenalex.org/property/hasSource> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
+
+<https://semopenalex.org/property/hasLocation> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
+
+<https://semopenalex.org/property/hasPrimaryLocation> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#> .
+
+<https://semopenalex.org/property/hasBestOaLocation> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "hasBestOaLocation"@en .
+
+<https://semopenalex.org/property/sourceType> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "sourceType"@en .
+
+<https://semopenalex.org/property/apcUsd> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "apcUsd"@en;
+  rdfs:comment "source's ar1cle processing charge in US Dollars, if available from DOAJ"@en .
+
+<https://semopenalex.org/property/fatcatId> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "fatcatId"@en .
+
+<https://semopenalex.org/property/abbreviatedName> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "abbreviatedName"@en .
+
+<https://semopenalex.org/property/hasHostOrganization> a owl:ObjectProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "hasHostOrganization"@en .
+
+<https://semopenalex.org/class/PublisherShape> a sh:NodeShape;
+  sh:property [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/citedByCount>;
+      sh:datatype xsd:integer
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/countsByYear>;
+      sh:class <https://semopenalex.org/class/CountsByYear>
+    ], [ a sh:PropertyShape;
+      sh:path <http://www.geonames.org/ontology#countryCode>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/hasParentPublisher>;
+      sh:class <https://semopenalex.org/class/Publisher>
+    ], [ a sh:PropertyShape;
+      sh:path <http://purl.org/dc/terms/created>;
+      sh:datatype xsd:date
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/level>;
+      sh:datatype xsd:integer
+    ], [ a sh:PropertyShape;
+      sh:path foaf:name;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <http://purl.org/spar/bido/h-index>;
+      sh:datatype xsd:integer
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/i10Index>;
+      sh:datatype xsd:integer
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/ror>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <http://purl.org/dc/terms/modified>;
+      sh:datatype xsd:date
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/2YrMeanCitedness>;
+      sh:datatype xsd:float
+    ], [ a sh:PropertyShape;
+      sh:path <https://dbpedia.org/ontology/alternativeName>;
+      sh:datatype xsd:string
+    ], [ a sh:PropertyShape;
+      sh:path <https://semopenalex.org/property/worksCount>;
+      sh:datatype xsd:integer
+    ];
+  sh:targetClass <https://semopenalex.org/class/Publisher> .
+
+<https://semopenalex.org/vocab#pdfUrl> a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://semopenalex.org/vocab#>;
+  rdfs:label "pdfUrl"@en .

--- a/semopenalex-app/data/templates/http%3A%2F%2Fwww.metaphactory.semopenalex.com%2Fapp%2FStart.html
+++ b/semopenalex-app/data/templates/http%3A%2F%2Fwww.metaphactory.semopenalex.com%2Fapp%2FStart.html
@@ -93,13 +93,17 @@
         }]
       }'
       relations='{
-        "<http://semopenalex.org/host-venue-placeholder>": [{
+        "<http://semopenalex.org/has-primary-location-placeholder>": [{
           "kind": "resource",
-          "queryPattern": "{ $subject <https://semopenalex.org/property/hasHostVenue>/<https://semopenalex.org/property/hasVenue> ?__value__ . }"
+          "queryPattern": "{ $subject <https://semopenalex.org/property/hasPrimaryLocation>/<https://semopenalex.org/property/hasSource> ?__value__ . }"
         }],
-         "<http://semopenalex.org/host-venue-placeholder-inverse>": [{
+        "<http://semopenalex.org/has-location-placeholder>": [{
           "kind": "resource",
-          "queryPattern": "{ $subject ^(<https://semopenalex.org/property/hasHostVenue>/<https://semopenalex.org/property/hasVenue>) ?__value__ . }"
+          "queryPattern": "{ $subject <https://semopenalex.org/property/hasLocation>/<https://semopenalex.org/property/hasSource> ?__value__ . }"
+        }],
+        "<http://semopenalex.org/has-best-oa-location-placeholder>": [{
+          "kind": "resource",
+          "queryPattern": "{ $subject <https://semopenalex.org/property/hasBestOaLocation>/<https://semopenalex.org/property/hasSource> ?__value__ . }"
         }],
          "<http://semopenalex.org/has-concept-placeholder-inverse>": [{
           "kind": "resource",
@@ -135,15 +139,19 @@
           "thumbnail": "/assets/images/icon-3.png"
         }, 
         {
-          "iri": "<https://semopenalex.org/class/Venue>",
-          "label": "Venue",
+          "iri": "<https://semopenalex.org/class/Source>",
+          "label": "Source",
           "thumbnail": "/assets/images/icon-4.png"
         },
         {
           "iri": "<https://semopenalex.org/class/Work>",
           "label": "Work",
           "thumbnail": "/assets/images/icon-2.png"
-        } 
+        }, {
+          "iri": "<https://semopenalex.org/class/Publisher>",
+          "label": "Publisher",
+          "thumbnail": "/assets/images/icon-1.png"
+        }
         ],
         "relations": [
           {  
@@ -173,14 +181,35 @@
           },
            {
             "hasDomain": "<https://semopenalex.org/class/Work>",
-            "iri": "<http://semopenalex.org/host-venue-placeholder>",
-            "hasRange": "<https://semopenalex.org/class/Venue>",
-            "label": "hasHostVenue",
-            "inverse": {
-              "iri": "<http://semopenalex.org/host-venue-placeholder-inverse>",
-              "label": "host Venue Of"
-            }
-          }, {
+            "iri": "<http://semopenalex.org/has-primary-location-placeholder>",
+            "hasRange": "<https://semopenalex.org/class/Source>",
+            "label": "hasSource (Primary Location)"
+          },
+          {
+            "hasDomain": "<https://semopenalex.org/class/Work>",
+            "iri": "<http://semopenalex.org/has-location-placeholder>",
+            "hasRange": "<https://semopenalex.org/class/Source>",
+            "label": "hasSource (Location)"
+          },
+          {
+            "hasDomain": "<https://semopenalex.org/class/Source>",
+            "iri": "<https://semopenalex.org/property/hasHostOrganization>",
+            "hasRange": "<https://semopenalex.org/class/Publisher>",
+            "label": "hasHostOrganization"
+          },
+          {
+            "hasDomain": "<https://semopenalex.org/class/Source>",
+            "iri": "<https://semopenalex.org/property/hasHostOrganization>",
+            "hasRange": "<https://semopenalex.org/class/Institution>",
+            "label": "hasHostOrganization"
+          },
+          {
+            "hasDomain": "<https://semopenalex.org/class/Work>",
+            "iri": "<http://semopenalex.org/has-best-oa-location-placeholder>",
+            "hasRange": "<https://semopenalex.org/class/Source>",
+            "label": "hasSource (Best OA Location)"
+          },
+           {
             "hasDomain": "<https://semopenalex.org/class/Work>",
             "iri": "<http://prismstandard.org/namespaces/basic/2.0/publicationDate>",
             "hasRange": "<http://www.w3.org/2001/XMLSchema#dateTime>",
@@ -292,14 +321,19 @@
                       {{>::disambiguation-institution-extra-info}}
                     </div>
                   {{/if}}
-                  {{#if (cond-eq domain.label 'Venue')}}
+                  {{#if (cond-eq domain.label 'Source')}}
                     <div>
-                      {{>::disambiguation-venue-extra-info}}
+                      {{>::disambiguation-source-extra-info}}
                     </div>
                   {{/if}}
                   {{#if (cond-eq domain.label 'Topic')}}
                     <div>
                       {{>::disambiguation-topic-extra-info}}
+                    </div>
+                  {{/if}}
+                  {{#if (cond-eq domain.label 'Publisher')}}
+                    <div>
+                      {{>::disambiguation-publisher-extra-info}}
                     </div>
                   {{/if}}
 
@@ -313,6 +347,18 @@
         {{>::search-result-holders}}
       
     </semantic-search>
+</template-fragment>
+
+<template-fragment id='disambiguation-publisher-extra-info'>
+  <semantic-query query='SELECT * { <{{resource.iri}}> ^<https://semopenalex.org/property/hasHostOrganization>/<http://xmlns.com/foaf/0.1/name> ?obj } LIMIT 5' template='{{> tmpl}}'>
+    <template id='tmpl'>
+       Publisher (Host Organization Of)
+      {{#each bindings}}
+          <semantic-link iri={{obj.value}}></semantic-link>
+           {{#if @last}}{{else}}, {{/if}}
+      {{/each}}
+    </template>
+  </semantic-query>
 </template-fragment>
 
 <template-fragment id='disambiguation-author-extra-info'>
@@ -358,7 +404,7 @@
   </semantic-query>
 </template-fragment>
 
-<template-fragment id='disambiguation-venue-extra-info'>
+<template-fragment id='disambiguation-source-extra-info'>
   <semantic-query query='SELECT * { 
   <{{resource.iri}}> <http://purl.org/dc/terms/publisher> ?publisher .
   } LIMIT 1' template='{{> tmpl}}'>
@@ -408,7 +454,7 @@
 <template-fragment id='count-template'>
 
   <div style='text-align: center; margin-top: 16px; font-size:14px;'>
-    SemOpenAlex is a <semantic-link iri='http://www.metaphacts.com/resource/assets/Datasets'>dataset</semantic-link> about scientific publications presented in the form of a knowledge graph with approximately 28.3 billion statements. {{>::icon-attribution}}
+    SemOpenAlex is a <semantic-link iri='http://www.metaphacts.com/resource/assets/Datasets'>dataset</semantic-link> about scientific publications presented in the form of a knowledge graph with approximately 26.4 billion statements. {{>::icon-attribution}}
   </div>
   <div style='margin: 16px;'>
     {{#if (cond-and (cond-gt searchTerm.length 2) (cond-eq loadingCounts false))}}
@@ -424,7 +470,7 @@
       <div data-flex-layout='rows stretch-stretch'>
         {{#each (array-sortBy domains (func (d) d.thumbnail) descending=false)}}
           {{#if (cond-gt count 0)}}
-            <div data-flex-self='size-1of5 md-half sm-full' class='KeywordTypeQuery--domainCardItem'>
+            <div data-flex-self='size-1of3 md-half sm-full' class='KeywordTypeQuery--domainCardItem'>
         
               <mp-event-trigger
                 type='KeywordTypeQuery.SelectDomain'
@@ -462,7 +508,7 @@
         <div data-flex-layout='rows stretch-stretch'>
           {{#each (array-sortBy domains (func (d) d.thumbnail) descending=false)}}
             {{#ifCond count "||" ../loadingCounts}}
-              <div data-flex-self='size-1of5 md-half sm-full' class='KeywordTypeQuery--domainCardItem'>
+              <div data-flex-self='size-1of3 md-half sm-full' class='KeywordTypeQuery--domainCardItem'>
                 <mp-event-trigger type='KeywordTypeQuery.SelectDomain' targets='["{{../componentId}}"]' data='{"domainIri": "{{iri}}"}'>
                   <button class='btn btn-secondary KeywordTypeQuery--domainCard {{#if selected}}KeywordTypeQuery--domainCard--selected{{/if}}' style='background: #F9F8F6'>
                     <div class='KeywordTypeQuery--domainCardThumbnail p-3'>
@@ -547,19 +593,19 @@
             {{>::overview-authors mode='author'}}
           {{/if}}
         {{/if}}
-        {{#if (cond-eq iri 'https://semopenalex.org/class/Venue')}}
+        {{#if (cond-eq iri 'https://semopenalex.org/class/Source')}}
           {{#if (cond-gt bindings.length 0)}}
-            {{>::overview-concept-venue-institution mode='venue'}}
+            {{>::overview-concept-source-institution mode='source'}}
           {{/if}}
         {{/if}}
         {{#if (cond-eq iri 'https://semopenalex.org/class/Institution')}}
           {{#if (cond-gt bindings.length 0)}}
-            {{>::overview-concept-venue-institution mode='institution'}}
+            {{>::overview-concept-source-institution mode='institution'}}
           {{/if}}
         {{/if}}
         {{#if (cond-eq iri 'http://www.w3.org/2004/02/skos/core#Concept')}}
           {{#if (cond-gt bindings.length 0)}}
-            {{>::overview-concept-venue-institution mode='concept'}}
+            {{>::overview-concept-source-institution mode='concept'}}
           {{/if}}
         {{/if}}
       </template>
@@ -615,9 +661,10 @@
             ?author <http://xmlns.com/foaf/0.1/name> ?name .
             ?publication <https://semopenalex.org/property/citedByCount> ?cited .
             OPTIONAL {
-              ?publication <https://semopenalex.org/property/hasHostVenue> ?hostVenue .
-              ?hostVenue <https://semopenalex.org/property/hasVenue> ?venue .
-              ?venue <http://purl.org/dc/terms/publisher> ?publisher .
+             
+              ?location <https://semopenalex.org/property/hasSource> ?source .
+              ?publication <https://semopenalex.org/property/hasLocation> ?location .
+              ?source <https://semopenalex.org/property/hasHostOrganization> ?publisher .
             }
             OPTIONAL {
               ?publication <http://purl.org/dc/terms/abstract> ?abstract .
@@ -765,14 +812,14 @@
   </semantic-query>
 </template-fragment>
 
-<template-fragment id='venue-institution-concepts'>
+<template-fragment id='source-institution-concepts'>
   <semantic-query query='
     SELECT ?concept  {
         
-        {{#if (cond-eq mode "venue")}}
-          BIND(<{{sub.value}}> as ?venue)
-          ?hostVenue <https://semopenalex.org/property/hasVenue> ?venue .
-          ?work <https://semopenalex.org/property/hasHostVenue> ?hostVenue .
+        {{#if (cond-eq mode "source")}}
+          BIND(<{{sub.value}}> as ?source)
+          ?location <https://semopenalex.org/property/hasSource> ?source .
+          ?work <https://semopenalex.org/property/hasLocation> ?location .
         {{/if}}
 
         {{#if (cond-eq mode "institution")}}
@@ -815,13 +862,13 @@
 </template-fragment>
 
 
-<template-fragment id="overview-concept-venue-institution">
+<template-fragment id="overview-concept-source-institution">
   <div class="row card publications" style='margin:8px'>
    
   <div class="publications__header">
     <div class="card__title">
-      {{#if (cond-eq mode "venue")}}
-        VENUES 
+      {{#if (cond-eq mode "source")}}
+        SOURCES
       {{/if}}
       {{#if (cond-eq mode "institution")}}
         INSTITUTIONS
@@ -852,7 +899,7 @@
             }
           {{/if}}
         
-          {{#if (cond-eq mode "venue")}}
+          {{#if (cond-eq mode "source")}}
             ?sub <http://xmlns.com/foaf/0.1/name> ?name .
             OPTIONAL {
               ?sub <http://purl.org/dc/terms/publisher> ?publisher ;
@@ -906,9 +953,9 @@
                 <div>Home Page: <a href='{{homepage.value}}' target='_blank'>{{homepage.value}}</a></div>
               {{/if}}
             </div>
-            {{#if (cond-or (cond-eq mode "venue") (cond-eq mode "institution"))}}
+            {{#if (cond-or (cond-eq mode "source") (cond-eq mode "institution"))}}
               <div class="row concepts" style="margin:3px;">
-                {{>::venue-institution-concepts}}
+                {{>::source-institution-concepts}}
               </div>
             {{/if}}
           </div>
@@ -1007,14 +1054,17 @@
                         {{#if (string-contains subject.value "author")}}
                           {{>::table-result-author-info  mode='author'}}
                         {{/if}}
-                        {{#if (string-contains subject.value "venue")}}
-                          {{>::table-result-concept-venue-institution-info mode='venue'}}
+                        {{#if (string-contains subject.value "source")}}
+                          {{>::table-result-concept-source-institution-publisher-info mode='source'}}
                         {{/if}}
                         {{#if (string-contains subject.value "institution")}}
-                          {{>::table-result-concept-venue-institution-info mode='institution'}}
+                          {{>::table-result-concept-source-institution-publisher-info mode='institution'}}
                         {{/if}}
                         {{#if (string-contains subject.value "concept")}}
-                          {{>::table-result-concept-venue-institution-info mode='concept'}}
+                          {{>::table-result-concept-source-institution-publisher-info mode='concept'}}
+                        {{/if}}
+                        {{#if (string-contains subject.value "publisher")}}
+                          {{>::table-result-concept-source-institution-publisher-info mode='publisher'}}
                         {{/if}}
                         
                         
@@ -1049,9 +1099,10 @@
         ?publication <http://purl.org/dc/terms/abstract> ?abstract .
       }
       OPTIONAL {
-        ?publication <https://semopenalex.org/property/hasHostVenue> ?hostVenue .
-        ?hostVenue <https://semopenalex.org/property/hasVenue> ?venue .
-        ?venue <http://purl.org/dc/terms/publisher> ?publisher .
+       
+        ?location <https://semopenalex.org/property/hasSource> ?source .
+        ?publication <https://semopenalex.org/property/hasLocation> ?location .
+        ?source <https://semopenalex.org/property/hasHostOrganization> ?publisher .
       }
       OPTIONAL {
         ?publication <https://semopenalex.org/property/hasVolume> ?volume .
@@ -1114,7 +1165,7 @@
   </semantic-query>
 </template-fragment>
 
-<template-fragment id="table-result-concept-venue-institution-info">
+<template-fragment id="table-result-concept-source-institution-publisher-info">
   <semantic-query 
     query='
       SELECT * { 
@@ -1129,9 +1180,19 @@
             ?sub <https://dbpedia.org/ontology/location>/<https://dbpedia.org/property/country> ?country .
           }
         {{/if}}
-        {{#if (cond-eq mode "venue")}}
+        {{#if (cond-eq mode "publisher")}}
+          OPTIONAL{
+            ?sub <http://www.geonames.org/ontology#countryCode> ?countryCode .
+          }
+           OPTIONAL{
+            ?sub <http://purl.org/spar/bido/h-index> ?hIndex .
+            ?sub <https://semopenalex.org/property/i10Index> ?i10Index .
+          }
+          
+        {{/if}}
+        {{#if (cond-eq mode "source")}}
           OPTIONAL {
-            ?sub <http://purl.org/dc/terms/publisher> ?publisher ;
+            ?sub <https://semopenalex.org/property/hasHostOrganization> ?publisher ;
               <https://semopenalex.org/property/isOa> ?isOa .
           }
           OPTIONAL {
@@ -1163,11 +1224,21 @@
                 {{#if city}}
                   LOCATED IN: <span>{{city.value}}</span>
                 {{/if}}
+                {{#if countryCode}}
+                  LOCATED IN: <span>{{countryCode.value}}</span>
+                {{/if}}
+                
                 {{#if country}}
                   <span>, {{country.value}}</span>
                 {{/if}}
               </div>
               <div class="publication__info">
+                {{#if hIndex}}
+                  h-Index: <span>{{hIndex.value}}</span><br>
+                {{/if}}
+                {{#if i10Index}}
+                  i10-Index: <span>{{i10Index.value}}</span>
+                {{/if}}
                 {{#if publisher}}{{publisher.value}} {{/if}}
                 {{#if isOa}}
                   <i class="fa {{#if (cond-eq isOa.value 'true')}}fa-unlock{{else}}fa-lock{{/if}}"></i>
@@ -1181,9 +1252,9 @@
                   <div>Home Page: <a href='{{homepage.value}}' target='_blank'>{{homepage.value}}</a></div>
                 {{/if}}
               </div>
-              {{#if (cond-or (cond-eq ../mode "venue") (cond-eq ../mode "institution"))}}
+              {{#if (cond-or (cond-eq ../mode "source") (cond-eq ../mode "institution"))}}
                 <div class="row concepts" style="margin:3px;">
-                  {{>::venue-institution-concepts mode=../mode}}
+                  {{>::source-institution-concepts mode=../mode}}
                 </div>
               {{/if}}
             </div>

--- a/semopenalex-app/ldp/assets/2023-04-30T11-46-semopenalex-Default-Diagram.trig
+++ b/semopenalex-app/ldp/assets/2023-04-30T11-46-semopenalex-Default-Diagram.trig
@@ -1,0 +1,365 @@
+@prefix Platform: <http://www.metaphacts.com/ontologies/platform#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://localhost:10214/container/ontodiaDiagramContainer/default_diagram/context> {
+  <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram> a ldp:Resource,
+      prov:Entity, <http://ontodia.org/schema/v1#Diagram>;
+    rdfs:label "Default Diagram";
+    prov:wasAttributedTo <http://www.metaphacts.com/resource/user/admin>;
+    prov:generatedAtTime "2023-04-30T11:41:05.062+02:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://ontodia.org/schema/v1#layoutData> _:genid-8a1df56b095d421c93f8073c5f51229a626-b0;
+    Platform:diagramForOntology <https://semopenalex.org/vocab#>;
+    Platform:diagramKind Platform:OntologyDiagram;
+    Platform:isDefaultDiagram "true";
+    <http://ontodia.org/schema/v1#linkTypeOptions> _:genid-8a1df56b095d421c93f8073c5f51229a626-b16 .
+  
+  <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b9;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Author> .
+  
+  <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b5;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Work> .
+  
+  <http://ontodia.org/data/l_ebfffe95255ed14673b0e0feb194f292> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#b05af3d161aa7b1cbc624e43d5713970>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_bcdd665f43dae452b67bbe7dbc9986f4> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#fe5d6c5f112271527e2c7abee8c5ea22>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_48b7fef904b4f42e364fdcdd2acd7dbf> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#abcbc6c65cb325168fe715e373960e7c>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b6;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/ConceptScore> .
+  
+  <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b1;
+    <http://ontodia.org/schema/v1#resource> skos:Concept .
+  
+  <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b2;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Concept> .
+  
+  <http://ontodia.org/data/l_b7aac6a476253be16fd761ec25f74b3b> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#451627809f2e7ca7411918e1373143f6>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_f652dc8f0b2c5bacd37aa0f695b38f10> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> skos:semanticRelation;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation-owl>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_73fa71226335eb205d0f8a7b6a0124e3> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#property> rdfs:subClassOf;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b3;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Institution> .
+  
+  <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b10;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Geo> .
+  
+  <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b12;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/CountsByYear> .
+  
+  <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b4;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/OpenAccess> .
+  
+  <http://ontodia.org/data/l_798a3fb22668f46994fe24612490cdda> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#fe3d9ddc90fd4837401ab65fb4f1b962>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_61848e1e4e1bc3173e9eb293e36144ee> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#8a8aecaca1e42caa6994bd80a9188415>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_9631e39f2fda07a16a6e7b6c29509dbd> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e6d6f1fbf0cd5a66ac9208072882dea6>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_b64693ced3f8b1e3619f1253befe9b44> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#0946e3c3725f942fa0f94070bc836046>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_048ebec1b391c97b0e6e2e009be58681> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_8e6ef5b93001e7aa44c460e4b3503f3c> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_f2f8fad05ca83652c218990c10f37df3> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b13;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/AuthorPosition> .
+  
+  <http://ontodia.org/data/l_b7ecc15f27b81c5c1368ea983acaaab6> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e87cdd7b584967125d063d517eed6e4e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_f940f97a60fdd05daa6950565c08fe80> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#af99a5a81b65696be8c769bf36a9b633>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>;
+    <http://ontodia.org/schema/v1#vertex> _:genid-8a1df56b095d421c93f8073c5f51229a626-b17 .
+  
+  <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b11;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Source> .
+  
+  <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b8;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Location> .
+  
+  <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b7;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Publisher> .
+  
+  <http://ontodia.org/data/l_be22b33ee113c2bfc4f58c68056e99d7> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_14eb78520e01a7eebeec186eb830f88f> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:232c9924ff7e9d2b5640d21586d192>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_0b68e30ba5304f6ec2fa3a67e5665657> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e8a0e16f9a3195b262e677cac1e8ac67>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_e69b4df2d6cc5edfe7f8a7a4743648f7> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#d206e9f60b0f09d55eaf45500c6eb411>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_da60a4ece1aac3ab7fadc6a5c3eeac9b> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:bda3b605cdd8f049125282f634478>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_68485a187a53e51a06d1ee02fc884b1c> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#189d841b1771b070e525aa80a66987e5>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_f5ac50797ed6aab843fac4cd643b4f26> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:2d28cdc9aab80cca53a5449bbd444>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_8a3cff5daf10d129b904d8c67de4cc92> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:1f1c1c22bfecf12e3dbe821d29bcd2>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_5dfdf2b99775a7209d2b2c617597be39> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:0ef76dd02cd2cc906492a486d43d9c8>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> _:genid-8a1df56b095d421c93f8073c5f51229a626-b18 .
+  
+  <http://ontodia.org/data/l_7369a620c3ce88b71df6970bc11a9d0e> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:10dc7944-3ed0-4ea9-9fd7-0f817865c196>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  <http://ontodia.org/data/l_706d3a1147b8f704bf4ba4a8f43b7fd7> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:8918c5ac-aa77-474e-ac7e-f89cffb7c00d>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> rdf:nil .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b0 a <http://ontodia.org/schema/v1#Layout>;
+    <http://ontodia.org/schema/v1#hasElement> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>,
+      <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>, <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>,
+      <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>, <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>,
+      <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>, <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5>,
+      <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>, <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792>,
+      <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>, <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>,
+      <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>, <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#hasLink> <http://ontodia.org/data/l_ebfffe95255ed14673b0e0feb194f292>,
+      <http://ontodia.org/data/l_bcdd665f43dae452b67bbe7dbc9986f4>, <http://ontodia.org/data/l_48b7fef904b4f42e364fdcdd2acd7dbf>,
+      <http://ontodia.org/data/l_b7aac6a476253be16fd761ec25f74b3b>, <http://ontodia.org/data/l_f652dc8f0b2c5bacd37aa0f695b38f10>,
+      <http://ontodia.org/data/l_73fa71226335eb205d0f8a7b6a0124e3>, <http://ontodia.org/data/l_798a3fb22668f46994fe24612490cdda>,
+      <http://ontodia.org/data/l_61848e1e4e1bc3173e9eb293e36144ee>, <http://ontodia.org/data/l_9631e39f2fda07a16a6e7b6c29509dbd>,
+      <http://ontodia.org/data/l_b64693ced3f8b1e3619f1253befe9b44>, <http://ontodia.org/data/l_048ebec1b391c97b0e6e2e009be58681>,
+      <http://ontodia.org/data/l_8e6ef5b93001e7aa44c460e4b3503f3c>, <http://ontodia.org/data/l_f2f8fad05ca83652c218990c10f37df3>,
+      <http://ontodia.org/data/l_b7ecc15f27b81c5c1368ea983acaaab6>, <http://ontodia.org/data/l_f940f97a60fdd05daa6950565c08fe80>,
+      <http://ontodia.org/data/l_be22b33ee113c2bfc4f58c68056e99d7>, <http://ontodia.org/data/l_14eb78520e01a7eebeec186eb830f88f>,
+      <http://ontodia.org/data/l_0b68e30ba5304f6ec2fa3a67e5665657>, <http://ontodia.org/data/l_e69b4df2d6cc5edfe7f8a7a4743648f7>,
+      <http://ontodia.org/data/l_da60a4ece1aac3ab7fadc6a5c3eeac9b>, <http://ontodia.org/data/l_68485a187a53e51a06d1ee02fc884b1c>,
+      <http://ontodia.org/data/l_f5ac50797ed6aab843fac4cd643b4f26>, <http://ontodia.org/data/l_8a3cff5daf10d129b904d8c67de4cc92>,
+      <http://ontodia.org/data/l_5dfdf2b99775a7209d2b2c617597be39>, <http://ontodia.org/data/l_7369a620c3ce88b71df6970bc11a9d0e>,
+      <http://ontodia.org/data/l_706d3a1147b8f704bf4ba4a8f43b7fd7> .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b16 a <http://ontodia.org/schema/v1#LinkTypeOptions>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation-owl>;
+    <http://ontodia.org/schema/v1#showLabel> true;
+    <http://ontodia.org/schema/v1#visible> false .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b1 <http://ontodia.org/schema/v1#xCoordValue>
+      196;
+    <http://ontodia.org/schema/v1#yCoordValue> -734 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b2 <http://ontodia.org/schema/v1#xCoordValue>
+      196;
+    <http://ontodia.org/schema/v1#yCoordValue> -460 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b3 <http://ontodia.org/schema/v1#xCoordValue>
+      -785;
+    <http://ontodia.org/schema/v1#yCoordValue> 626 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b4 <http://ontodia.org/schema/v1#xCoordValue>
+      776;
+    <http://ontodia.org/schema/v1#yCoordValue> 978 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b5 <http://ontodia.org/schema/v1#xCoordValue>
+      776;
+    <http://ontodia.org/schema/v1#yCoordValue> 78 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b6 <http://ontodia.org/schema/v1#xCoordValue>
+      776;
+    <http://ontodia.org/schema/v1#yCoordValue> -709 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b7 <http://ontodia.org/schema/v1#xCoordValue>
+      -795;
+    <http://ontodia.org/schema/v1#yCoordValue> 109 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b8 <http://ontodia.org/schema/v1#xCoordValue>
+      196;
+    <http://ontodia.org/schema/v1#yCoordValue> 275 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b9 <http://ontodia.org/schema/v1#xCoordValue>
+      215;
+    <http://ontodia.org/schema/v1#yCoordValue> 683 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b10 <http://ontodia.org/schema/v1#xCoordValue>
+      -334;
+    <http://ontodia.org/schema/v1#yCoordValue> 1034 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b11 <http://ontodia.org/schema/v1#xCoordValue>
+      -334;
+    <http://ontodia.org/schema/v1#yCoordValue> 72 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b12 <http://ontodia.org/schema/v1#xCoordValue>
+      -334;
+    <http://ontodia.org/schema/v1#yCoordValue> -327 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b13 <http://ontodia.org/schema/v1#xCoordValue>
+      1211;
+    <http://ontodia.org/schema/v1#yCoordValue> 826 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b17 rdf:first _:genid-8a1df56b095d421c93f8073c5f51229a626-b14;
+    rdf:rest rdf:nil .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b14 <http://ontodia.org/schema/v1#xCoordValue>
+      1.3103822629969418E3;
+    <http://ontodia.org/schema/v1#yCoordValue> 410 .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b18 rdf:first _:genid-8a1df56b095d421c93f8073c5f51229a626-b15;
+    rdf:rest rdf:nil .
+  
+  _:genid-8a1df56b095d421c93f8073c5f51229a626-b15 <http://ontodia.org/schema/v1#xCoordValue>
+      -6.89152484848485E2;
+    <http://ontodia.org/schema/v1#yCoordValue> -2.3240673939393946E2 .
+  
+  _:e363641938f04b77937c24ef11b61dcf827 ldp:contains <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram> .
+}
+
+{
+  _:e363641938f04b77937c24ef11b61dcf827 a ldp:Container, ldp:Resource, prov:Entity .
+}

--- a/semopenalex-app/ldp/assets/http%3A%2F%2Flocalhost%3A10214%2Fcontainer%2FontodiaDiagramContainer%2Fdefault_diagram.trig
+++ b/semopenalex-app/ldp/assets/http%3A%2F%2Flocalhost%3A10214%2Fcontainer%2FontodiaDiagramContainer%2Fdefault_diagram.trig
@@ -1,269 +1,17 @@
-@prefix Platform: <http://www.metaphacts.com/ontologies/platform#> .
-@prefix prov: <http://www.w3.org/ns/prov#> .
-@prefix ldp: <http://www.w3.org/ns/ldp#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram/context> {
-  <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram> a ldp:Resource,
-      prov:Entity, <http://ontodia.org/schema/v1#Diagram>;
-    rdfs:label "Default Diagram";
-    prov:wasAttributedTo <http://www.metaphacts.com/resource/user/admin>;
-    prov:generatedAtTime "2023-04-30T11:41:05.062+02:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
-    <http://ontodia.org/schema/v1#layoutData> _:genid-8a1df56b095d421c93f8073c5f51229a626-b0;
-    Platform:diagramForOntology <https://semopenalex.org/vocab#>;
-    Platform:diagramKind Platform:OntologyDiagram;
-    Platform:isDefaultDiagram "true";
-    <http://ontodia.org/schema/v1#linkTypeOptions> _:genid-8a1df56b095d421c93f8073c5f51229a626-b16 .
+  <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram> a <http://ontodia.org/schema/v1#Diagram>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Default Diagram";
+    <http://ontodia.org/schema/v1#layoutData> _:genid-346857dbe621472c9980bbfced2dd850200-836726C641FB5915AF3DCEC73E937302;
+    <http://www.metaphacts.com/ontologies/platform#diagramForOntology> <https://semopenalex.org/vocab#>;
+    <http://www.metaphacts.com/ontologies/platform#diagramKind> <http://www.metaphacts.com/ontologies/platform#OntologyDiagram>;
+    <http://www.metaphacts.com/ontologies/platform#isDefaultDiagram> "true";
+    <http://ontodia.org/schema/v1#linkTypeOptions> _:genid-346857dbe621472c9980bbfced2dd850200-A37B0346D9918461A3104D688EDE0A11;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.metaphacts.com/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2023-05-01T18:28:33.940Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   
-  <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b9;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Author> .
-  
-  <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b5;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Work> .
-  
-  <http://ontodia.org/data/l_ebfffe95255ed14673b0e0feb194f292> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#b05af3d161aa7b1cbc624e43d5713970>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_bcdd665f43dae452b67bbe7dbc9986f4> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#fe5d6c5f112271527e2c7abee8c5ea22>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_48b7fef904b4f42e364fdcdd2acd7dbf> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#abcbc6c65cb325168fe715e373960e7c>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b6;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/ConceptScore> .
-  
-  <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b1;
-    <http://ontodia.org/schema/v1#resource> skos:Concept .
-  
-  <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b2;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Concept> .
-  
-  <http://ontodia.org/data/l_b7aac6a476253be16fd761ec25f74b3b> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#451627809f2e7ca7411918e1373143f6>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_f652dc8f0b2c5bacd37aa0f695b38f10> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> skos:semanticRelation;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation-owl>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_73fa71226335eb205d0f8a7b6a0124e3> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#property> rdfs:subClassOf;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b3;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Institution> .
-  
-  <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b10;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Geo> .
-  
-  <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b12;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/CountsByYear> .
-  
-  <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b4;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/OpenAccess> .
-  
-  <http://ontodia.org/data/l_798a3fb22668f46994fe24612490cdda> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#fe3d9ddc90fd4837401ab65fb4f1b962>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_61848e1e4e1bc3173e9eb293e36144ee> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#8a8aecaca1e42caa6994bd80a9188415>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_9631e39f2fda07a16a6e7b6c29509dbd> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e6d6f1fbf0cd5a66ac9208072882dea6>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_b64693ced3f8b1e3619f1253befe9b44> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#0946e3c3725f942fa0f94070bc836046>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_048ebec1b391c97b0e6e2e009be58681> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_8e6ef5b93001e7aa44c460e4b3503f3c> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_f2f8fad05ca83652c218990c10f37df3> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b13;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/AuthorPosition> .
-  
-  <http://ontodia.org/data/l_b7ecc15f27b81c5c1368ea983acaaab6> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e87cdd7b584967125d063d517eed6e4e>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_f940f97a60fdd05daa6950565c08fe80> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#af99a5a81b65696be8c769bf36a9b633>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>;
-    <http://ontodia.org/schema/v1#vertex> _:genid-8a1df56b095d421c93f8073c5f51229a626-b17 .
-  
-  <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b11;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Source> .
-  
-  <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b8;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Location> .
-  
-  <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00> a <http://ontodia.org/schema/v1#Element>;
-    <http://ontodia.org/schema/v1#isExpanded> true;
-    <http://ontodia.org/schema/v1#position> _:genid-8a1df56b095d421c93f8073c5f51229a626-b7;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Publisher> .
-  
-  <http://ontodia.org/data/l_be22b33ee113c2bfc4f58c68056e99d7> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_14eb78520e01a7eebeec186eb830f88f> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:232c9924ff7e9d2b5640d21586d192>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_0b68e30ba5304f6ec2fa3a67e5665657> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e8a0e16f9a3195b262e677cac1e8ac67>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_e69b4df2d6cc5edfe7f8a7a4743648f7> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#d206e9f60b0f09d55eaf45500c6eb411>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_da60a4ece1aac3ab7fadc6a5c3eeac9b> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:bda3b605cdd8f049125282f634478>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_68485a187a53e51a06d1ee02fc884b1c> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#189d841b1771b070e525aa80a66987e5>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_f5ac50797ed6aab843fac4cd643b4f26> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:2d28cdc9aab80cca53a5449bbd444>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_8a3cff5daf10d129b904d8c67de4cc92> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:1f1c1c22bfecf12e3dbe821d29bcd2>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_5dfdf2b99775a7209d2b2c617597be39> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:0ef76dd02cd2cc906492a486d43d9c8>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
-    <http://ontodia.org/schema/v1#vertex> _:genid-8a1df56b095d421c93f8073c5f51229a626-b18 .
-  
-  <http://ontodia.org/data/l_7369a620c3ce88b71df6970bc11a9d0e> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:10dc7944-3ed0-4ea9-9fd7-0f817865c196>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  <http://ontodia.org/data/l_706d3a1147b8f704bf4ba4a8f43b7fd7> a <http://ontodia.org/schema/v1#Link>;
-    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:8918c5ac-aa77-474e-ac7e-f89cffb7c00d>;
-    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
-    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
-    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
-    <http://ontodia.org/schema/v1#vertex> rdf:nil .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b0 a <http://ontodia.org/schema/v1#Layout>;
+  _:genid-346857dbe621472c9980bbfced2dd850200-836726C641FB5915AF3DCEC73E937302 a <http://ontodia.org/schema/v1#Layout>;
     <http://ontodia.org/schema/v1#hasElement> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>,
       <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>, <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>,
       <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>, <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>,
@@ -286,80 +34,325 @@
       <http://ontodia.org/data/l_5dfdf2b99775a7209d2b2c617597be39>, <http://ontodia.org/data/l_7369a620c3ce88b71df6970bc11a9d0e>,
       <http://ontodia.org/data/l_706d3a1147b8f704bf4ba4a8f43b7fd7> .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b16 a <http://ontodia.org/schema/v1#LinkTypeOptions>;
+  _:genid-346857dbe621472c9980bbfced2dd850200-A37B0346D9918461A3104D688EDE0A11 a <http://ontodia.org/schema/v1#LinkTypeOptions>;
     <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation-owl>;
     <http://ontodia.org/schema/v1#showLabel> true;
     <http://ontodia.org/schema/v1#visible> false .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b1 <http://ontodia.org/schema/v1#xCoordValue>
-      196;
-    <http://ontodia.org/schema/v1#yCoordValue> -734 .
+  <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-A5048B3257F8D36777B4EFD039D642A4;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Author> .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b2 <http://ontodia.org/schema/v1#xCoordValue>
-      196;
-    <http://ontodia.org/schema/v1#yCoordValue> -460 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b3 <http://ontodia.org/schema/v1#xCoordValue>
-      -785;
-    <http://ontodia.org/schema/v1#yCoordValue> 626 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b4 <http://ontodia.org/schema/v1#xCoordValue>
-      776;
-    <http://ontodia.org/schema/v1#yCoordValue> 978 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b5 <http://ontodia.org/schema/v1#xCoordValue>
-      776;
-    <http://ontodia.org/schema/v1#yCoordValue> 78 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b6 <http://ontodia.org/schema/v1#xCoordValue>
-      776;
-    <http://ontodia.org/schema/v1#yCoordValue> -709 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b7 <http://ontodia.org/schema/v1#xCoordValue>
-      -795;
-    <http://ontodia.org/schema/v1#yCoordValue> 109 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b8 <http://ontodia.org/schema/v1#xCoordValue>
-      196;
-    <http://ontodia.org/schema/v1#yCoordValue> 275 .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b9 <http://ontodia.org/schema/v1#xCoordValue>
+  _:genid-346857dbe621472c9980bbfced2dd850200-A5048B3257F8D36777B4EFD039D642A4 <http://ontodia.org/schema/v1#xCoordValue>
       215;
     <http://ontodia.org/schema/v1#yCoordValue> 683 .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b10 <http://ontodia.org/schema/v1#xCoordValue>
+  <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-A2FD134A4DC1963E32916ED71270E4E5;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Work> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-A2FD134A4DC1963E32916ED71270E4E5 <http://ontodia.org/schema/v1#xCoordValue>
+      776;
+    <http://ontodia.org/schema/v1#yCoordValue> 78 .
+  
+  <http://ontodia.org/data/l_ebfffe95255ed14673b0e0feb194f292> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#b05af3d161aa7b1cbc624e43d5713970>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_bcdd665f43dae452b67bbe7dbc9986f4> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#fe5d6c5f112271527e2c7abee8c5ea22>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_48b7fef904b4f42e364fdcdd2acd7dbf> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#abcbc6c65cb325168fe715e373960e7c>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-8A1F2D760DCA1E3CD41CC6613680049B;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/ConceptScore> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-8A1F2D760DCA1E3CD41CC6613680049B <http://ontodia.org/schema/v1#xCoordValue>
+      776;
+    <http://ontodia.org/schema/v1#yCoordValue> -709 .
+  
+  <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-FD46F824799D330440D09041DEB9477A;
+    <http://ontodia.org/schema/v1#resource> <http://www.w3.org/2004/02/skos/core#Concept> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-FD46F824799D330440D09041DEB9477A <http://ontodia.org/schema/v1#xCoordValue>
+      196;
+    <http://ontodia.org/schema/v1#yCoordValue> -734 .
+  
+  <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-C7F4E05A0C9E4E9E440928533ECFD263;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Concept> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-C7F4E05A0C9E4E9E440928533ECFD263 <http://ontodia.org/schema/v1#xCoordValue>
+      196;
+    <http://ontodia.org/schema/v1#yCoordValue> -460 .
+  
+  <http://ontodia.org/data/l_b7aac6a476253be16fd761ec25f74b3b> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#451627809f2e7ca7411918e1373143f6>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_f652dc8f0b2c5bacd37aa0f695b38f10> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://www.w3.org/2004/02/skos/core#semanticRelation>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation-owl>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_73fa71226335eb205d0f8a7b6a0124e3> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#property> <http://www.w3.org/2000/01/rdf-schema#subClassOf>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-2297D2D31B5E3CAAAFBF48623A03EC54;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Institution> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-2297D2D31B5E3CAAAFBF48623A03EC54 <http://ontodia.org/schema/v1#xCoordValue>
+      -785;
+    <http://ontodia.org/schema/v1#yCoordValue> 626 .
+  
+  <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-830E26C30091536AA1A9C3FD58DF968A;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Geo> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-830E26C30091536AA1A9C3FD58DF968A <http://ontodia.org/schema/v1#xCoordValue>
       -334;
     <http://ontodia.org/schema/v1#yCoordValue> 1034 .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b11 <http://ontodia.org/schema/v1#xCoordValue>
-      -334;
-    <http://ontodia.org/schema/v1#yCoordValue> 72 .
+  <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-FEA6A2F2251A2C30686B7D107AF5AD0B;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/CountsByYear> .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b12 <http://ontodia.org/schema/v1#xCoordValue>
+  _:genid-346857dbe621472c9980bbfced2dd850200-FEA6A2F2251A2C30686B7D107AF5AD0B <http://ontodia.org/schema/v1#xCoordValue>
       -334;
     <http://ontodia.org/schema/v1#yCoordValue> -327 .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b13 <http://ontodia.org/schema/v1#xCoordValue>
+  <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-95F078BE1916EA862C4E2EE60F626D1A;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/OpenAccess> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-95F078BE1916EA862C4E2EE60F626D1A <http://ontodia.org/schema/v1#xCoordValue>
+      776;
+    <http://ontodia.org/schema/v1#yCoordValue> 978 .
+  
+  <http://ontodia.org/data/l_798a3fb22668f46994fe24612490cdda> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#fe3d9ddc90fd4837401ab65fb4f1b962>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_61848e1e4e1bc3173e9eb293e36144ee> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#8a8aecaca1e42caa6994bd80a9188415>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_9631e39f2fda07a16a6e7b6c29509dbd> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e6d6f1fbf0cd5a66ac9208072882dea6>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_05b7ef2de019d435459a65234c5391b5>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_b64693ced3f8b1e3619f1253befe9b44> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#0946e3c3725f942fa0f94070bc836046>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_c9f3c82ef0ae0a48506245e13a160792>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_048ebec1b391c97b0e6e2e009be58681> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_8e6ef5b93001e7aa44c460e4b3503f3c> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_c32ee5565ec455496fe83efec81c7fdc>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_f2f8fad05ca83652c218990c10f37df3> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-6DDFA86BD58BE87B623F8591942731E1;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/AuthorPosition> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-6DDFA86BD58BE87B623F8591942731E1 <http://ontodia.org/schema/v1#xCoordValue>
       1211;
     <http://ontodia.org/schema/v1#yCoordValue> 826 .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b17 rdf:first _:genid-8a1df56b095d421c93f8073c5f51229a626-b14;
-    rdf:rest rdf:nil .
+  <http://ontodia.org/data/l_b7ecc15f27b81c5c1368ea983acaaab6> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e87cdd7b584967125d063d517eed6e4e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_dfa1e15f91978eef627c1af619a1be3d>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b14 <http://ontodia.org/schema/v1#xCoordValue>
+  <http://ontodia.org/data/l_f940f97a60fdd05daa6950565c08fe80> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#af99a5a81b65696be8c769bf36a9b633>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_1a8f24ce58360a2fa67ee245f3d6dca0>;
+    <http://ontodia.org/schema/v1#vertex> _:genid-346857dbe621472c9980bbfced2dd850200-37C71F0B82F10599BB0D1CEAA944343C .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-37C71F0B82F10599BB0D1CEAA944343C <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
+      _:genid-346857dbe621472c9980bbfced2dd850200-F7C689F92E78FBD9E20DFC85048C4B63;
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-F7CAF6BF1916391E2FBF6AC733139B55;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Source> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-F7CAF6BF1916391E2FBF6AC733139B55 <http://ontodia.org/schema/v1#xCoordValue>
+      -334;
+    <http://ontodia.org/schema/v1#yCoordValue> 72 .
+  
+  <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-92575933B4F74F036649455B12473FDD;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Location> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-92575933B4F74F036649455B12473FDD <http://ontodia.org/schema/v1#xCoordValue>
+      196;
+    <http://ontodia.org/schema/v1#yCoordValue> 275 .
+  
+  <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00> a <http://ontodia.org/schema/v1#Element>;
+    <http://ontodia.org/schema/v1#isExpanded> true;
+    <http://ontodia.org/schema/v1#position> _:genid-346857dbe621472c9980bbfced2dd850200-48B28E672CC9A0DE0F7716628E18373A;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/class/Publisher> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-48B28E672CC9A0DE0F7716628E18373A <http://ontodia.org/schema/v1#xCoordValue>
+      -795;
+    <http://ontodia.org/schema/v1#yCoordValue> 109 .
+  
+  <http://ontodia.org/data/l_be22b33ee113c2bfc4f58c68056e99d7> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#643f980183729bdf11919a5652a68f8e>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_14eb78520e01a7eebeec186eb830f88f> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:232c9924ff7e9d2b5640d21586d192>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_990222da97caa8926e45b5836b4347f4>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_0b68e30ba5304f6ec2fa3a67e5665657> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#e8a0e16f9a3195b262e677cac1e8ac67>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_e69b4df2d6cc5edfe7f8a7a4743648f7> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#d206e9f60b0f09d55eaf45500c6eb411>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_da60a4ece1aac3ab7fadc6a5c3eeac9b> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:bda3b605cdd8f049125282f634478>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_68485a187a53e51a06d1ee02fc884b1c> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <https://semopenalex.org/vocab#189d841b1771b070e525aa80a66987e5>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_4161474aaf04e7cc4761a03f72d88191>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_f5ac50797ed6aab843fac4cd643b4f26> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:2d28cdc9aab80cca53a5449bbd444>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_8a3cff5daf10d129b904d8c67de4cc92> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:1f1c1c22bfecf12e3dbe821d29bcd2>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_07abfee8a593e60721b135fbb92ab81c>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_5dfdf2b99775a7209d2b2c617597be39> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:0ef76dd02cd2cc906492a486d43d9c8>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_7f3981d824b716c479442eeff713cd00>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_88c983080b513b1505de3312841597ab>;
+    <http://ontodia.org/schema/v1#vertex> _:genid-346857dbe621472c9980bbfced2dd850200-0ED93EF93AAAA2C93CEB5FB9B61C7378 .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-0ED93EF93AAAA2C93CEB5FB9B61C7378 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
+      _:genid-346857dbe621472c9980bbfced2dd850200-A5E88321E769F54E30D01367D2311F12;
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_7369a620c3ce88b71df6970bc11a9d0e> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:10dc7944-3ed0-4ea9-9fd7-0f817865c196>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e56684e8dc4c5c96825a36c25b87dcaf>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  <http://ontodia.org/data/l_706d3a1147b8f704bf4ba4a8f43b7fd7> a <http://ontodia.org/schema/v1#Link>;
+    <http://ontodia.org/schema/v1#resource> <http://ontodia.org/schema/v1#blank:rdf:8918c5ac-aa77-474e-ac7e-f89cffb7c00d>;
+    <http://ontodia.org/schema/v1#property> <http://www.metaphacts.com/metaschema#relation>;
+    <http://ontodia.org/schema/v1#source> <http://ontodia.org/data/e_e265c4af4aa0997ccf85ab1042fa8cf8>;
+    <http://ontodia.org/schema/v1#target> <http://ontodia.org/data/e_47d8bb7ab7f0470ab49bf06d8eb47159>;
+    <http://ontodia.org/schema/v1#vertex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+  
+  _:genid-346857dbe621472c9980bbfced2dd850200-F7C689F92E78FBD9E20DFC85048C4B63 <http://ontodia.org/schema/v1#xCoordValue>
       1.3103822629969418E3;
     <http://ontodia.org/schema/v1#yCoordValue> 410 .
   
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b18 rdf:first _:genid-8a1df56b095d421c93f8073c5f51229a626-b15;
-    rdf:rest rdf:nil .
-  
-  _:genid-8a1df56b095d421c93f8073c5f51229a626-b15 <http://ontodia.org/schema/v1#xCoordValue>
+  _:genid-346857dbe621472c9980bbfced2dd850200-A5E88321E769F54E30D01367D2311F12 <http://ontodia.org/schema/v1#xCoordValue>
       -6.89152484848485E2;
     <http://ontodia.org/schema/v1#yCoordValue> -2.3240673939393946E2 .
   
-  _:e363641938f04b77937c24ef11b61dcf827 ldp:contains <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram> .
-}
-
-{
-  _:e363641938f04b77937c24ef11b61dcf827 a ldp:Container, ldp:Resource, prov:Entity .
+  <http://www.metaphacts.com/ontologies/platform#ontodiaDiagramContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://localhost:10214/container/ontodiaDiagramContainer/default_diagram> .
 }

--- a/semopenalex-app/ldp/assets/http%3A%2F%2Fwww.metaphacts.com%2Fontologies%2Fplatform%23ontodiaDiagramContainer.trig
+++ b/semopenalex-app/ldp/assets/http%3A%2F%2Fwww.metaphacts.com%2Fontologies%2Fplatform%23ontodiaDiagramContainer.trig
@@ -1,0 +1,11 @@
+
+<http://www.metaphacts.com/ontologies/platform#ontodiaDiagramContainer/context> {
+  <http://www.metaphacts.com/ontologies/platform#ontodiaDiagramContainer> a <http://www.w3.org/ns/ldp#Container>,
+      <http://www.w3.org/ns/ldp#Resource>, <http://www.w3.org/ns/prov#Entity>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Ontodia Diagram Container";
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.metaphacts.com/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2023-05-01T18:28:33.913Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  <http://www.metaphacts.com/ontologies/platform#rootContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.metaphacts.com/ontologies/platform#ontodiaDiagramContainer> .
+}

--- a/semopenalex-app/plugin.properties
+++ b/semopenalex-app/plugin.properties
@@ -1,3 +1,3 @@
 plugin.id=semopenalex-app
-plugin.provider=Metaphacts
-plugin.version=2.0.0
+plugin.provider=metaphacts
+plugin.version=3.0.0


### PR DESCRIPTION
The following items are addressed:

- Added second version of ontology with SHACL
- Added a default ontology diagram as part of an app.