### PR TITLE
DKG-643: Fix export ontology with default diagram and add missing configs for for resolvable IRIs

### DIFF
--- a/semopenalex-app/config/environment.prop
+++ b/semopenalex-app/config/environment.prop
@@ -1,4 +1,4 @@
 sparqlMaxExecutionTime = 120
 sparqlHttpReadTimeout = 120
-pathsToRewrite = /author/,/concept/,/countsbyyear/,/geo/,/hostvenue/,/conceptscore/,/openaccess/,/work/,/source/,/publisher/,/institution/,/authorship/,/topic/,/keyword/,/domain/,/field/,/subfield/,/countsByYear/
+pathsToRewrite = /author/,/concept/,/countsbyyear/,/geo/,/hostvenue/,/conceptscore/,/openaccess/,/work/,/source/,/publisher/,/institution/,/authorship/,/topic/,/keyword/,/domain/,/field/,/subfield/,/countsByYear/,/articleProcessingChargeList/,/funder/,/location/,/articleProcessingChargePaid/
 platformBaseIri = https://semopenalex.org

--- a/semopenalex-app/config/environment.prop
+++ b/semopenalex-app/config/environment.prop
@@ -1,4 +1,4 @@
 sparqlMaxExecutionTime = 120
 sparqlHttpReadTimeout = 120
-pathsToRewrite = /author/,/concept/,/countsbyyear/,/geo/,/hostvenue/,/conceptscore/,/openaccess/,/work/,/source/,/publisher/,/institution/,/authorship/,/topic/,/keyword/,/domain/,/field/,/subfield/,/countsByYear/,/articleProcessingChargeList/,/funder/,/location/,/articleProcessingChargePaid/
+pathsToRewrite = /author/,/concept/,/countsbyyear/,/geo/,/hostvenue/,/conceptscore/,/openaccess/,/work/,/source/,/publisher/,/institution/,/authorship/,/topic/,/keyword/,/domain/,/field/,/subfield/,/countsByYear/,/articleProcessingChargeList/,/funder/,/location/,/articleProcessingChargePaid/,/ontology/
 platformBaseIri = https://semopenalex.org

--- a/semopenalex-app/config/roles/role-export-diagram.prop
+++ b/semopenalex-app/config/roles/role-export-diagram.prop
@@ -1,0 +1,3 @@
+#Definition of role export-diagram
+#Mon Nov 25 08:35:34 UTC 2024
+permissions=api\:ldp\:container\:*\:export

--- a/semopenalex-app/config/roles/role-sparql-editor-view.prop
+++ b/semopenalex-app/config/roles/role-sparql-editor-view.prop
@@ -1,0 +1,3 @@
+#Definition of role sparql-editor-view
+#Mon Jun 17 10:04:58 UTC 2024
+permissions=ui\:page\:sparql-editor


### PR DESCRIPTION
The following items are addressed:

- Fix export ontology with default diagram
- add missing configs for for resolvable IRIs
    -  `/articleProcessingChargeList/`
    - `/funder/`
    - `/location/`
    - `/articleProcessingChargePaid/`